### PR TITLE
cleaner switch to pyfftw (than the previous pull request)

### DIFF
--- a/scintellometry/folding/fold_aro.py
+++ b/scintellometry/folding/fold_aro.py
@@ -2,8 +2,19 @@
 from __future__ import division, print_function
 
 import numpy as np
-# use FFT from scipy, since unlike numpy it does not cast up to complex128
-from scipy.fftpack import rfft, irfft, rfftfreq
+try:
+    import pyfftw
+    pyfftw.interfaces.cache.enable()
+    from pyfftw.interfaces.scipy_fftpack import rfft, irfft, rfftfreq
+    import multiprocessing
+    _NTHREADS = min(4, multiprocessing.cpu_count())
+    _fftargs = {'threads': _NTHREADS,
+                'planner_effort': 'FFTW_ESTIMATE'}
+except(ImportError):
+    print("Consider installing pyfftw: https://github.com/hgomersall/pyFFTW")
+    # use FFT from scipy, since unlike numpy it does not cast up to complex128
+    from scipy.fftpack import rfft, irfft, rfftfreq
+    _fftargs = {}
 import astropy.units as u
 
 from fromfile import fromfile
@@ -126,12 +137,12 @@ def fold(file1, dtype, samplerate, fedge, fedge_at_top, nchan,
 
             vals = raw.astype(np.float32)
             if coherent:
-                fine = rfft(vals, axis=0, overwrite_x=True)
+                fine = rfft(vals, axis=0, overwrite_x=True, **_fftargs)
                 fine *= dedisperse
-                vals = irfft(fine, axis=0, overwrite_x=True)
+                vals = irfft(fine, axis=0, overwrite_x=True, **_fftargs)
 
             chan2 = rfft(vals.reshape(-1, nchan*2), axis=-1,
-                         overwrite_x=True)**2
+                         overwrite_x=True, **_fftargs)**2
             # rfft: Re[0], Re[1], Im[1], ..., Re[n/2-1], Im[n/2-1], Re[n/2]
             # re-order to Num.Rec. format: Re[0], Re[n/2], Re[1], ....
             power = np.hstack((chan2[:,:1]+chan2[:,-1:],


### PR DESCRIPTION
After contacting https://github.com/hgomersall/pyFFTW, the 
pyfftw.interfaces.scipy_fftpack rfft and irfft were changed to have consistent input/output 
to the equivalent scipy.fftpack routines.

Previously pyfftw used numpy ordering of arrays, so one couldn't simply have a drop-in replacement. Using the newest git version of pyfftw, however, and one can simply drop in the much-faster pyfftw function calls.

This commit implements that.
