### PR TITLE
Allow for optional output of complex voltages

### DIFF
--- a/scintellometry/trials/crab/reduce_data.py
+++ b/scintellometry/trials/crab/reduce_data.py
@@ -47,5 +47,6 @@ if __name__ == '__main__':
         args.telescope, args.date, tstart=args.tstart, tend=args.tend,
         nchan=args.nchan, ngate=args.ngate, ntbin=args.ntbin,
         ntw_min=args.ntw_min, rfi_filter_raw=args.rfi_filter_raw,
-        do_waterfall=args.waterfall, do_foldspec=args.foldspec,
-        dedisperse=args.dedisperse, fref=args.fref, verbose=args.verbose)
+        do_waterfall=args.waterfall, do_foldspec=args.foldspec, 
+        do_voltage=args.voltage, dedisperse=args.dedisperse, 
+        fref=args.fref, verbose=args.verbose)


### PR DESCRIPTION
This change allows a -volt or --voltage option to be specified in order to output the complex voltages. The voltages are outputted in the same manner as a waterfall (only complex). 

Note, I notice that if I do something like (for a single polarization) 
`(waterfall-voltage*np.conj(voltage))/waterfall`, 
I get things of order 1e-8. Does this seem consistent with round off error for these data types?

As well, it seems np.bincount does not support complex weights, so I had to split this line to add the real and imaginary parts separately. Is this fine? 